### PR TITLE
Add dotenv command to generate .env

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM golang:1.10-alpine as build
+FROM golang:1.11-alpine as build
 
 RUN apk update && apk add git
 RUN go get -u github.com/golang/dep/cmd/dep

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -84,6 +84,12 @@
   revision = "0b12d6b5"
 
 [[projects]]
+  name = "github.com/joho/godotenv"
+  packages = ["."]
+  revision = "23d116af351c84513e1946b527c88823e476be13"
+  version = "v1.3.0"
+
+[[projects]]
   name = "github.com/pkg/errors"
   packages = ["."]
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
@@ -104,6 +110,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "5d4badb3db9f275e024257609613168a80c1f9bc146f93b98d5a11f30b19508e"
+  inputs-digest = "7cefb712d6c13a4e630e4c69a83a4caaa0526b6dcd02db7f0007edc71e82cba2"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 SSM Parent
 ----------
 
-This is a parent process for Docker with one addition: it can read from AWS SSM Parameter store.
+This is mostly a parent process for Docker with one addition: it can read from AWS SSM Parameter store.
 
 The way it works is that ssm-parent can be used as an entrypoint for Docker. Firstly, it retrieves all specified parameters, then injects them to the environment,
 and finally runs the command.
@@ -45,7 +45,6 @@ The result will be merged as this:
 That should be pretty self-explanatory.
 
 ```
-$ssm-parent help                                                                                                         <aws:hosting>
 SSM-Parent is a docker entrypoint.
 
 It gets specified parameters (possibly secret) from AWS SSM Parameter Store,
@@ -55,11 +54,13 @@ Usage:
   ssm-parent [command]
 
 Available Commands:
+  dotenv      Writes dotenv file
   help        Help about any command
   print       Prints the specified parameters.
   run         Runs the specified command
 
 Flags:
+  -e, --expand             Expand arguments and values using shell-style syntax
   -h, --help               help for ssm-parent
   -n, --name stringArray   Name of the SSM parameter to retrieve. Can be specified multiple times.
   -p, --path stringArray   Path to a SSM parameter. Can be specified multiple times.
@@ -94,6 +95,16 @@ echo "Bootstrapping Caddy"
 envsubst < /etc/Caddyfile.env > /etc/Caddyfile
 
 exec $@
+```
+
+### .env file generation
+
+Sometimes you just want a .env file, and now it is also possible.
+
+Just specify all the same parameters, but use `dotenv` command instead with a filename to generate `.env` file.
+```
+./ssm-parent dotenv -r -p /project/environment dotenv.env
+2018/10/01 16:37:59  info Wrote the .env file       filename=dotenv.env
 ```
 
 ### How to build

--- a/cmd/dotenv.go
+++ b/cmd/dotenv.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"github.com/apex/log"
+	"github.com/imdario/mergo"
+	"github.com/joho/godotenv"
+	"github.com/spf13/cobra"
+	"github.com/springload/ssm-parent/ssm"
+)
+
+// dotenvCmd represents the dotenv command
+var dotenvCmd = &cobra.Command{
+	Use:   "dotenv <filename>",
+	Short: "Writes dotenv file",
+	Long:  `Gathers parameters from SSM Parameter store, writes .env file and exits`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		megamap := make(map[string]string)
+		parameters, err := ssm.GetParameters(names, paths, expand, strict, recursive)
+		if err != nil {
+			log.WithError(err).Fatal("Can't get parameters")
+		}
+		for _, parameter := range parameters {
+			err = mergo.Merge(&megamap, &parameter, mergo.WithOverride)
+			if err != nil {
+				log.WithError(err).Fatal("Can't merge maps")
+			}
+		}
+		for key, value := range megamap {
+			if expand {
+				megamap[key] = ssm.ExpandValue(value)
+			}
+		}
+
+		err = godotenv.Write(megamap, args[0])
+		if err != nil {
+			log.WithError(err).Fatal("Can't write the dotenv file")
+		} else {
+			log.WithFields(log.Fields{"filename": args[0]}).Info("Wrote the .env file")
+
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(dotenvCmd)
+
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,5 +39,5 @@ func init() {
 	rootCmd.PersistentFlags().StringArrayVarP(&names, "name", "n", []string{}, "Name of the SSM parameter to retrieve. Can be specified multiple times.")
 	rootCmd.PersistentFlags().BoolVarP(&recursive, "recursive", "r", false, "Walk through the provided SSM paths recursively.")
 	rootCmd.PersistentFlags().BoolVarP(&strict, "strict", "s", false, "Strict mode. Fail if found less parameters than number of names.")
-	rootCmd.PersistentFlags().BoolVarP(&expand, "expand", "e", false, "Expand arguments and values using /bin/sh")
+	rootCmd.PersistentFlags().BoolVarP(&expand, "expand", "e", false, "Expand arguments and values using shell-style syntax")
 }


### PR DESCRIPTION
Can be used for a conventional setup. For example `exec-pre-app` command can be used in `uwsgi` config to generate `.env` file for a 12-factor-enabled Django application.