### PR TITLE
Add variable name trimming

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ trim_name_prefix will match any variables starting with `starts_with` and will r
 There is practically no limit on the number of transformations and they are applied in order from top to the bottom.
 
 Below there is an example that recursively gets parameters from `/$PROJECT/common/` and `/$PROJECT/$ENVIRONMENT` and constructs variables out of
-`DATABASE_URL` to be consumed by an PHP application. It also renames `AWS_BUCKET` to `AWS_S3_BUCKET` and removes `DATABASE_URL` afterwards.
+`DATABASE_URL` to be consumed by an PHP application. It also renames `AWS_BUCKET` to `AWS_S3_BUCKET`, removes `DATABASE_URL` and trims a leading underscore from any variable name that may start with `_PHP`.
 
 ```yaml
 recursive: true

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Template transformation uses [Go templates](https://golang.org/pkg/text/template
 
 There are the following extra functions available in templates: url_host, url_user, url_password, url_path, url_scheme and trim_prefix. The current list of the custom functions can be found here https://github.com/springload/ssm-parent/blob/master/ssm/transformations/template_funcs.go#L9
 
-trim_name_prefix will match any variables starting with `startswith` and will remove the `trim` string from the start of the corresponding variable names.
+trim_name_prefix will match any variables starting with `starts_with` and will remove the `trim` string from the start of the corresponding variable names.
 
 There is practically no limit on the number of transformations and they are applied in order from top to the bottom.
 
@@ -131,7 +131,7 @@ transformations:
     - action: trim_name_prefix
       rule:
           trim: "_"
-          startswith: "_PHP"
+          starts_with: "_PHP"
 ```
 
 ### Example Dockerfile part

--- a/README.md
+++ b/README.md
@@ -95,11 +95,14 @@ The supported transformations are:
 1. rename - renames env vars
 2. delete - deletes env vars
 3. template - templates env vars
+4. trim_name_prefix - removes a prefix from variable names
 
-Rename and template transormations expect a dictionary rule. The delete transormation expects an array.
+Rename, template, trim_name_prefix transormations expect a dictionary rule. The delete transormation expects an array.
 Template transformation uses [Go templates](https://golang.org/pkg/text/template/), and the environment variables map is passed as `.`.
 
 There are the following extra functions available in templates: url_host, url_user, url_password, url_path, url_scheme and trim_prefix. The current list of the custom functions can be found here https://github.com/springload/ssm-parent/blob/master/ssm/transformations/template_funcs.go#L9
+
+trim_name_prefix will match any variables starting with `startswith` and will remove the `trim` string from the start of the corresponding variable names.
 
 There is practically no limit on the number of transformations and they are applied in order from top to the bottom.
 
@@ -125,6 +128,10 @@ transformations:
     - action: delete
       rule:
           - DATABASE_URL
+    - action: trim_name_prefix
+      rule:
+          trim: "_"
+          startswith: "_PHP"
 ```
 
 ### Example Dockerfile part

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The supported transformations are:
 3. template - templates env vars
 4. trim_name_prefix - removes a prefix from variable names
 
-Rename, template, trim_name_prefix transormations expect a dictionary rule. The delete transormation expects an array.
+Rename, template, trim_name_prefix transformations expect a dictionary rule. The delete transformation expects an array.
 Template transformation uses [Go templates](https://golang.org/pkg/text/template/), and the environment variables map is passed as `.`.
 
 There are the following extra functions available in templates: url_host, url_user, url_password, url_path, url_scheme and trim_prefix. The current list of the custom functions can be found here https://github.com/springload/ssm-parent/blob/master/ssm/transformations/template_funcs.go#L9

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -89,6 +89,15 @@ func initSettings() {
 				}).WithError(err).Fatal("can't decode config")
 			}
 			transformationsList = append(transformationsList, tr)
+		case "trim_name_prefix":
+			tr := new(transformations.TrimTransformation)
+			if err := mapstructure.Decode(t, tr); err != nil {
+				log.WithFields(log.Fields{
+					"transformation_number": n,
+					"transformation_action": hint.Action,
+				}).WithError(err).Fatal("can't decode config")
+			}
+			transformationsList = append(transformationsList, tr)
 
 		default:
 			log.Warnf("Got unparsed action: %s", hint.Action)

--- a/ssm/transformations/actions.go
+++ b/ssm/transformations/actions.go
@@ -69,3 +69,21 @@ func (t *TemplateTransformation) Transform(source map[string]string) (map[string
 
 	return source, nil
 }
+
+// TrimTransformation modifies the keys in the input map
+type TrimTransformation struct {
+	Action string
+	Rule   map[string]string
+}
+
+func (t *TrimTransformation) Transform(source map[string]string) (map[string]string, error) {
+	if _, found := t.Rule["trim"]; !found {
+		return source, fmt.Errorf("\"trim\" rule not set")
+	}
+	if _, found := t.Rule["startswith"]; !found {
+		return source, fmt.Errorf("\"startswith\" rule not set")
+	}
+	TrimKeys(source, t.Rule["trim"], t.Rule["startswith"])
+
+	return source, nil
+}

--- a/ssm/transformations/actions.go
+++ b/ssm/transformations/actions.go
@@ -80,10 +80,10 @@ func (t *TrimTransformation) Transform(source map[string]string) (map[string]str
 	if _, found := t.Rule["trim"]; !found {
 		return source, fmt.Errorf("\"trim\" rule not set")
 	}
-	if _, found := t.Rule["startswith"]; !found {
-		return source, fmt.Errorf("\"startswith\" rule not set")
+	if _, found := t.Rule["starts_with"]; !found {
+		return source, fmt.Errorf("\"starts_with\" rule not set")
 	}
-	TrimKeys(source, t.Rule["trim"], t.Rule["startswith"])
+	TrimKeys(source, t.Rule["trim"], t.Rule["starts_with"])
 
 	return source, nil
 }

--- a/ssm/transformations/trim.go
+++ b/ssm/transformations/trim.go
@@ -1,0 +1,18 @@
+package transformations
+
+import (
+	"strings"
+)
+
+func TrimKeys(parameters map[string]string, trim string, startswith string) error {
+
+	for key, value := range parameters {
+		if strings.HasPrefix(key, startswith) {
+			parameters[strings.TrimPrefix(key, trim)] = value
+			delete(parameters, key)
+		}
+	}
+
+	return nil
+
+}

--- a/ssm/transformations/trim.go
+++ b/ssm/transformations/trim.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 )
 
-func TrimKeys(parameters map[string]string, trim string, startsWith string) error {
+func TrimKeys(parameters map[string]string, trim string, startsWith string) {
 
 	for key, value := range parameters {
 		if strings.HasPrefix(key, startsWith) {
@@ -12,7 +12,5 @@ func TrimKeys(parameters map[string]string, trim string, startsWith string) erro
 			delete(parameters, key)
 		}
 	}
-
-	return nil
 
 }

--- a/ssm/transformations/trim.go
+++ b/ssm/transformations/trim.go
@@ -4,10 +4,10 @@ import (
 	"strings"
 )
 
-func TrimKeys(parameters map[string]string, trim string, startswith string) error {
+func TrimKeys(parameters map[string]string, trim string, startsWith string) error {
 
 	for key, value := range parameters {
-		if strings.HasPrefix(key, startswith) {
+		if strings.HasPrefix(key, startsWith) {
 			parameters[strings.TrimPrefix(key, trim)] = value
 			delete(parameters, key)
 		}

--- a/ssm/transformations/trim_test.go
+++ b/ssm/transformations/trim_test.go
@@ -17,9 +17,7 @@ func TestTrimKeys(t *testing.T) {
 		"another_value": "_ANOTHER_PARAMETER",
 	}
 
-	if err := TrimKeys(parameters, "_", "_PREFIXED_"); err != nil {
-		t.Errorf("expected no error, but got: %s", err)
-	}
+	TrimKeys(parameters, "_", "_PREFIXED_")
 
 	// Swap result keys and values to check against expectations
 	result := make(map[string]string)

--- a/ssm/transformations/trim_test.go
+++ b/ssm/transformations/trim_test.go
@@ -1,0 +1,35 @@
+package transformations
+
+import (
+	"testing"
+)
+
+func TestTrimKeys(t *testing.T) {
+	t.Setenv("ENVIRONMENT", "teststaging")
+
+	parameters := map[string]string{
+		"_PREFIXED_PARAMETER": "prefixed_value",
+		"_ANOTHER_PARAMETER":  "another_value",
+	}
+
+	expecting := map[string]string{
+		"prefixed_value": "PREFIXED_PARAMETER",
+		"another_value": "_ANOTHER_PARAMETER",
+	}
+
+	if err := TrimKeys(parameters, "_", "_PREFIXED_"); err != nil {
+		t.Errorf("expected no error, but got: %s", err)
+	}
+
+	// Swap result keys and values to check against expectations
+	result := make(map[string]string)
+	for key, value := range parameters {
+		result[value] = key
+	}
+
+	for val, expected_param := range expecting {
+		if result[val] != expected_param {
+			t.Errorf("'%s's key should be '%s', but got '%s'", val, expected_param, result[val])
+		}
+	}
+}

--- a/ssm/transformations/trim_test.go
+++ b/ssm/transformations/trim_test.go
@@ -27,9 +27,9 @@ func TestTrimKeys(t *testing.T) {
 		result[value] = key
 	}
 
-	for val, expected_param := range expecting {
-		if result[val] != expected_param {
-			t.Errorf("'%s's key should be '%s', but got '%s'", val, expected_param, result[val])
+	for val, expectedParam := range expecting {
+		if result[val] != expectedParam {
+			t.Errorf("'%s's key should be '%s', but got '%s'", val, expectedParam, result[val])
 		}
 	}
 }


### PR DESCRIPTION
This allows us to trim a prefix from a set of variables with a common starting string.

e.g., With these variables set in SSM:
```
_PHP_MAX_CHILDREN=4
_PHP_START_SERVERS=2
_PHP_MIN_SPARE_SERVERS=1
_PHP_MAX_SPARE_SERVERS=3
_PHP_MAX_REQUEST=1
_NOT_TRIMMED=1
```

and the following rule:
```
  - action: trim_name_prefix
    rule:
      trim: "_"
      startsWith: "_PHP"
```

We would end up with:
```
PHP_MAX_CHILDREN=4
PHP_START_SERVERS=2
PHP_MIN_SPARE_SERVERS=1
PHP_MAX_SPARE_SERVERS=3
PHP_MAX_REQUEST=1
_NOT_TRIMMED=1
```