### PR TITLE
chore: bumped app to go 1.27

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -27,7 +27,7 @@ jobs:
         run: go mod download
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v9.3.0
 
       - name: build the app
         run: go build

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,7 +1,6 @@
 name: "Test the build"
 
 on:
-  push:
   pull_request:
 
 jobs:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -14,7 +14,7 @@ jobs:
       - name: set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.24.x
+          go-version: 1.27.x
       - name: cache modules
         uses: actions/cache@v4
         with:

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -19,7 +19,7 @@ jobs:
       - name: set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24.x
+          go-version: 1.27.x
 
       - name: install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24.x
+          go-version: 1.27.x
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,9 @@
-issues:
-  exclude-rules:
-    - path: ssm/parameters\.go
-      linters:
-        - staticcheck
-      text: "SA1019.*aws-sdk-go"
+version: "2"
+
+linters:
+  exclusions:
+    rules:
+      - path: ssm/parameters\.go
+        linters:
+          - staticcheck
+        text: "SA1019.*aws-sdk-go"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine as build
+FROM golang:1.27-alpine as build
 
 RUN apk update && apk add git
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -38,7 +38,9 @@ var runCmd = &cobra.Command{
 			log.WithError(err).Fatal("Can't get parameters")
 		}
 		for key, value := range parameters {
-			os.Setenv(key, value)
+			if err := os.Setenv(key, value); err != nil {
+				log.WithError(err).WithFields(log.Fields{"key": key}).Fatal("Can't set environment variable")
+			}
 		}
 
 		command, err := exec.LookPath(args[0])

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.24
+go 1.27
 
-toolchain go1.24.13
+toolchain go1.27.1

--- a/ssm/parameters.go
+++ b/ssm/parameters.go
@@ -39,7 +39,7 @@ func collectJsonParameters(responseParameters []*ssm.Parameter) (parameters []ma
 	for _, parameter := range responseParameters {
 		value := make(map[string]string)
 		if innerErr := json.Unmarshal([]byte(aws.StringValue(parameter.Value)), &value); innerErr != nil {
-			errors = append(errors, fmt.Errorf("Can't unmarshal json from '%s': %s", aws.StringValue(parameter.Name), innerErr))
+			errors = append(errors, fmt.Errorf("can't unmarshal json from '%s': %s", aws.StringValue(parameter.Name), innerErr))
 		} else {
 			parameters = append(parameters, value)
 		}
@@ -69,7 +69,7 @@ func getJsonSSMParametersByPaths(paths []string, strict, recursive bool) (parame
 		},
 		)
 		if innerErr != nil {
-			err = multierror.Append(err, fmt.Errorf("Can't get parameters from path '%s': %s", path, innerErr))
+			err = multierror.Append(err, fmt.Errorf("can't get parameters from path '%s': %s", path, innerErr))
 		}
 	}
 
@@ -91,7 +91,7 @@ func getJsonSSMParameters(names []string, strict bool) (parameters []map[string]
 	}
 	if len(response.Parameters) < len(names) {
 		if strict {
-			err = multierror.Append(err, fmt.Errorf("Found %d parameters from %d names", len(response.Parameters), len(names)))
+			err = multierror.Append(err, fmt.Errorf("found %d parameters from %d names", len(response.Parameters), len(names)))
 		} else {
 			var found []string
 			for _, f := range response.Parameters {
@@ -140,7 +140,7 @@ func getPlainSSMParametersByPaths(paths []string, strict, recursive bool) (param
 		},
 		)
 		if innerErr != nil {
-			err = multierror.Append(err, fmt.Errorf("Can't get parameters from path '%s': %s", path, innerErr))
+			err = multierror.Append(err, fmt.Errorf("can't get parameters from path '%s': %s", path, innerErr))
 		}
 	}
 	return
@@ -161,7 +161,7 @@ func getPlainSSMParameters(names []string, strict bool) (parameters []map[string
 	}
 	if len(response.Parameters) < len(names) {
 		if strict {
-			err = multierror.Append(err, fmt.Errorf("Found %d parameters from %d names", len(response.Parameters), len(names)))
+			err = multierror.Append(err, fmt.Errorf("found %d parameters from %d names", len(response.Parameters), len(names)))
 		} else {
 			var found []string
 			for _, f := range response.Parameters {


### PR DESCRIPTION
Updated app from go v1.24.x (reached EOL February 10, 2026) to v1.27.x