### PR TITLE
feat: renovate major deps config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,17 @@
       "platformAutomerge": true
     },
     {
+      "groupName": "all major github actions",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["major"],
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true
+    },
+    {
+      "groupName": "all major dependencies",
       "matchPackageNames": ["*"],
+      "excludeManagers": ["github-actions"],
       "matchUpdateTypes": ["major"],
       "automerge": false
     }


### PR DESCRIPTION
updated renovate config to group major github-actions deps in one group and all other major deps into another, enabling auto merge for the github-actions deps